### PR TITLE
fix: correctly link nested tags when root tag is one character (e.g. #a/b)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export default class GraphNestedTagsPlugin extends Plugin {
 			for (const id in nodes) {
 				if (nodes[id].type === "tag") {
 					last_tag = id;
-					for (let i = id.length - 1; i > 2; i--) {
+					for (let i = id.length - 1; i >= 2; i--) {
 						if (id[i] === "/") {
 							parent = id.slice(0, i);
 							if (!(parent in nodes)) {


### PR DESCRIPTION
## Problem
The global graph fails to draw a parent edge for tags like #a/a.
Root cause: the backward scan in src/main.ts stops at `i > 2`, skipping the `/` at index 2 when root tag is one character (e.g. #a/b).

<img height="500" src="https://github.com/user-attachments/assets/a8e7fc45-8dbd-46ba-99a4-bbe5efc56f9e" />

## Fix
Change the guard to `i >= 2`, allowing the loop to evaluate the character at index 2.

<img height="500" alt="image" src="https://github.com/user-attachments/assets/374bb6d8-a334-45da-b905-dbe30544e0b3" />

Verified in Obsidian v1.9.6 with a test vault.


